### PR TITLE
Always put google repo above jcenter

### DIFF
--- a/framework/build.gradle
+++ b/framework/build.gradle
@@ -24,10 +24,10 @@ ext {
 
 buildscript {
     repositories {
-        jcenter()
         maven {
             url "https://maven.google.com"
         }
+        jcenter()
     }
 
     dependencies {

--- a/spec/fixtures/android_studio_project/build.gradle
+++ b/spec/fixtures/android_studio_project/build.gradle
@@ -2,6 +2,7 @@
 
 buildscript {
     repositories {
+        google()
         jcenter()
     }
     dependencies {
@@ -14,6 +15,7 @@ buildscript {
 
 allprojects {
     repositories {
+        google()
         jcenter()
     }
 }

--- a/test/build.gradle
+++ b/test/build.gradle
@@ -20,6 +20,7 @@
 
 buildscript {
     repositories {
+        google()
         jcenter()
     }
     dependencies {
@@ -32,6 +33,7 @@ buildscript {
 
 allprojects {
     repositories {
+        google()
         jcenter()
     }
 }


### PR DESCRIPTION
Here we are mimicking this commit: https://github.com/apache/cordova-android/commit/2c10545cd80c7d47f19f18f50a2f94af19656b0e to be compatible with 6.3.x