### PR TITLE
Maven needs to take priority over jcenter

### DIFF
--- a/bin/templates/project/build.gradle
+++ b/bin/templates/project/build.gradle
@@ -21,10 +21,10 @@ apply plugin: 'com.android.application'
 
 buildscript {
     repositories {
-        jcenter()
         maven {
             url "https://maven.google.com"
         }
+        jcenter()
     }
 
     // Switch the Android Gradle plugin version requirement depending on the
@@ -39,10 +39,10 @@ buildscript {
 // Allow plugins to declare Maven dependencies via build-extras.gradle.
 allprojects {
     repositories {
-        jcenter()
         maven {
             url "https://maven.google.com"
         }
+        jcenter()
     }
 }
 


### PR DESCRIPTION
In #1 we ported over apache/cordova-android#523, but this was not enough.  We also need to change the template file.